### PR TITLE
这里会导致一个严重bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,9 @@
 *.js     text
 *.ts     text
 *.sql    text
+*.png    binary
+*.ico    binary
+*.icns   binary
 
 *.csproj text merge=union
 *.sln    text merge=union eol=crlf


### PR DESCRIPTION
Windows换行符是crlf，linux是lf，mac是cr。但是attributes把所有的换行符都改成了lf，来做到统一，结果把图片的也修改了，导致electron在打包win和mac时候会失败，linux打包正常。

在开头使用* text把所有文件全部指定为text了，所以会影响到图片格式的，这里过滤出图标需要的格式

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
